### PR TITLE
Add allowlist functionality and regex matching

### DIFF
--- a/Sources/hyper-focus/action_handler.swift
+++ b/Sources/hyper-focus/action_handler.swift
@@ -27,9 +27,7 @@ enum ActionHandler {
             }
             log("app is in block_apps, hiding application to prevent usage")
             // TODO: sometimes this hide method does not work
-            //NSWorkspace.shared.frontmostApplication!.hide()
-            NSWorkspace.shared.frontmostApplication!.terminate()
-            
+            NSWorkspace.shared.frontmostApplication!.hide()
             return true
         }
 

--- a/Sources/hyper-focus/hyper_focus.swift
+++ b/Sources/hyper-focus/hyper_focus.swift
@@ -30,6 +30,9 @@ struct Configuration: Codable {
         var block_hosts: [String]
         var block_urls: [String]
         var block_apps: [String]
+        var allow_hosts: [String]
+        var allow_urls: [String]
+        var allow_apps: [String]
     }
 
     var initial_wake: String?

--- a/Sources/hyper-focus/schedule_manager.swift
+++ b/Sources/hyper-focus/schedule_manager.swift
@@ -14,7 +14,10 @@ class ScheduleManager {
     let BLANK_SCHEDULE = Configuration.ScheduleItem(
         block_hosts: [],
         block_urls: [],
-        block_apps: []
+        block_apps: [],
+        allow_hosts: [],
+        allow_urls: [],
+        allow_apps: []
     )
 
     init(_ config: Configuration? = nil) {

--- a/schema.json
+++ b/schema.json
@@ -45,6 +45,24 @@
               "type": "string"
             }
           },
+          "allow_hosts": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "allow_urls": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "allow_apps": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
           "start_script": {
             "type": "string"
           },
@@ -52,7 +70,7 @@
             "type": "string"
           }
         },
-        "required": ["name", "block_hosts", "block_urls", "block_apps"]
+        "required": ["name", "block_hosts", "block_urls", "block_apps", "allow_hosts", "allow_urls", "allow_apps"]
       }
     }
   },


### PR DESCRIPTION
Right now, this is only a draft with a really quick and dirty implementation because I don't really know Swift  (but wanted to use the software because after trying the other options, I agree with your conclusions).

I've made it so that the patterns in all lists are matched with regex rather than simple substring matching, and I've added some "allow lists" that "undo" the action of the block list.
That is, if a pattern is matched by both block list and allow list the allow list will take precedence and the item should not be blocked.

The intended use case (for me, at least), is to have a global (or almost global) block pattern set, and then selectively allow a few domains.